### PR TITLE
Fix CLS from font loading on hero sections

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,6 +27,21 @@ const ogImageURL = new URL(image, Astro.site);
 <!doctype html>
 <html lang="en">
   <head>
+    <style>html, body { margin: 0; padding: 0; }</style>
+    <link
+      rel="preload"
+      href="/fonts/SourceSerif4Variable-Roman.ttf.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="/fonts/InterVariable.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <meta charset="UTF-8" />
     <meta name="theme-color" content="#171717" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -21,8 +21,9 @@
 /* Fallback font with adjusted metrics to minimize FOUT */
 @font-face {
   font-family: "Source Serif Fallback";
-  src: local("Times New Roman");
-  size-adjust: 104%;
+  src: local("Georgia"), local("Times New Roman");
+  font-display: swap;
+  size-adjust: 93%;
   ascent-override: 97%;
   descent-override: 27%;
   line-gap-override: 0%;


### PR DESCRIPTION
- Add inline margin reset to prevent body margin shift before CSS loads
- Preload Source Serif 4 and Inter variable fonts
- Improve fallback font: use Georgia over Times New Roman, add font-display: swap, tune size-adjust from 104% to 93%