### PR TITLE
Hide all job postings — all positions filled

### DIFF
--- a/src/content/jobs/breakfast-cook.mdx
+++ b/src/content/jobs/breakfast-cook.mdx
@@ -7,7 +7,7 @@ reportsTo: "Head Chef / Kitchen Manager"
 employmentType: "full-time / part-time"
 wage: "$14/hr + tips"
 pinned: false
-draft: false
+draft: true
 ---
 
 ## Position Overview

--- a/src/content/jobs/housekeeper.mdx
+++ b/src/content/jobs/housekeeper.mdx
@@ -7,7 +7,7 @@ reportsTo: "Winery Manager"
 employmentType: "full-time / part-time"
 wage: "$13/hr + tips"
 pinned: false
-draft: false
+draft: true
 ---
 
 ## Position Overview

--- a/src/content/jobs/wine-spirit-clerk.mdx
+++ b/src/content/jobs/wine-spirit-clerk.mdx
@@ -8,7 +8,7 @@ employmentType: "full-time / part-time"
 wage: "$14/hr + tips"
 ageRequirement: 21
 pinned: false
-draft: false
+draft: true
 ---
 
 ## Position Overview

--- a/src/content/stories/were-hiring.mdx
+++ b/src/content/stories/were-hiring.mdx
@@ -5,7 +5,7 @@ date: 2026-03-08
 featuredImage: "./_images/winery-entrance.webp"
 featuredImageAlt: "The entrance to Valiant Vineyards Winery with welcome sign and oak barrels"
 pinned: true
-draft: false
+draft: true
 ---
 
 ## Come Work With Us

--- a/src/pages/careers/index.astro
+++ b/src/pages/careers/index.astro
@@ -83,10 +83,19 @@ const sortedJobs = allJobs.sort((a, b) => {
             ))}
           </div>
         ) : (
-          <div class="text-center py-16">
-            <p class="text-lg text-muted-foreground">
-              No open positions at this time. Check back soon!
+          <div class="text-center py-16 max-w-lg mx-auto">
+            <p class="font-serif text-xl text-foreground font-medium">
+              All Positions Filled
             </p>
+            <p class="mt-3 text-muted-foreground leading-relaxed">
+              We don't have any open positions right now, but we're always growing. Check back soon for new opportunities to join the Valiant Vineyards family.
+            </p>
+            <a
+              href="/contact/"
+              class="mt-6 inline-block rounded-md bg-gold px-6 py-3 text-sm font-medium text-white shadow transition-colors hover:bg-gold-dark"
+            >
+              Get in Touch
+            </a>
           </div>
         )
       }
@@ -94,6 +103,7 @@ const sortedJobs = allJobs.sort((a, b) => {
   </section>
 
   <!-- Bottom CTA -->
+  {sortedJobs.length > 0 && (
   <section class="border-t border-neutral-200">
     <div class="container mx-auto px-4 lg:px-8 py-16 lg:py-20 text-center max-w-2xl">
       <h2 class="font-serif text-xl font-semibold text-foreground sm:text-2xl">
@@ -110,6 +120,7 @@ const sortedJobs = allJobs.sort((a, b) => {
       </a>
     </div>
   </section>
+  )}
 </BaseLayout>
 
 <style>


### PR DESCRIPTION
## Summary
- Set `draft: true` on all 3 job postings (breakfast cook, housekeeper, wine/spirit clerk) and the "We're Hiring" story
- Polished the careers page empty state with a warmer message and "Get in Touch" link
- Bottom CTA ("Don't see the right fit?") now conditionally hidden when no jobs are active

All careers infrastructure (application form, backend, schemas) remains intact — flip `draft: false` to reactivate.