### PR TITLE
Ignore local plan files; document menu refresh runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ pnpm-debug.log*
 # Claude Code local settings
 .claude/settings.local.json
 
+# Local-only Claude Code implementation plans (scratch space, not source of truth)
+docs/plans/
+
 # Output from Astro previews
 .output/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,16 @@ Sorting: pinned items first, then by date (events use `eventDate` with `date` fa
 **Events**: Copy `src/content/events/0-TEMPLATE.mdx`, rename, update frontmatter
 **Stories**: Copy `src/content/stories/0-TEMPLATE.mdx`, rename, update frontmatter
 
+## Updating the Banquet Menu
+
+The banquet menu PDF refreshes ~2× per year. The filename is intentionally versionless so updates require no code changes.
+
+1. Replace `public/downloads/banquet-menu.pdf` with the new PDF (same filename).
+2. Commit on a feature branch, open a PR, merge.
+3. Cloudflare Pages will redeploy automatically. Previously shared links keep working.
+
+Linked from `src/pages/weddings.astro` and `src/pages/private-events.astro` — do not rename the file.
+
 ## Environment Variables
 
 Required in Cloudflare Pages dashboard:


### PR DESCRIPTION
## Summary
- Add `docs/plans/` to `.gitignore` — treat Claude Code implementation plans as local-only scratch space (they go stale once executed; the merged code and commit messages are the source of truth)
- Add a short "Updating the Banquet Menu" runbook to `CLAUDE.md` so the ~2×/year refresh process is documented in-tree

## Test plan
- [ ] Confirm `git status` no longer surfaces `docs/plans/` as untracked
- [ ] Confirm CLAUDE.md renders cleanly on GitHub